### PR TITLE
Fix for `generate-fragments` creates empty fragments

### DIFF
--- a/src/GenerateFragments.ts
+++ b/src/GenerateFragments.ts
@@ -388,7 +388,7 @@ ${fragment}`
     }
 
     if (constructorName === "GraphQLObjectType") {
-      if (fragmentType === this.fragmentType.NO_RELATIONS) return null;
+      // if (fragmentType === this.fragmentType.NO_RELATIONS) return null;
       let typeName = null;
       // if(field.name !== undefined)
       typeName =


### PR DESCRIPTION
Simple workaround for https://github.com/develomark/graphql-cli-generate-fragments/issues/4 
I've been using the package with this change for weeks in production, using very complicated queries without a problem. No empty fragments are generated anymore. Would be nice if this works for you too, I'd much rather use your package from npm, than installing my fork.